### PR TITLE
Add observer to rotation events

### DIFF
--- a/UIImageViewAligned.swift
+++ b/UIImageViewAligned.swift
@@ -209,6 +209,7 @@ open class UIImageViewAligned: UIImageView {
     }
     
     private func setup(image: UIImage? = nil, highlightedImage: UIImage? = nil) {
+        addRotationObserver()
         realImageView = UIImageView(image: image ?? super.image, highlightedImage: highlightedImage ?? super.highlightedImage)
         realImageView?.frame = bounds
         realImageView?.autoresizingMask = [.flexibleWidth, .flexibleHeight]
@@ -216,7 +217,11 @@ open class UIImageViewAligned: UIImageView {
         addSubview(realImageView!)
     }
     
-    private func updateLayout() {
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    @objc public func updateLayout() {
         let realSize = realContentSize
         var realFrame = CGRect(origin: CGPoint(x: (bounds.size.width - realSize.width) / 2.0,
                                                y: (bounds.size.height - realSize.height) / 2.0),
@@ -253,5 +258,10 @@ open class UIImageViewAligned: UIImageView {
     
     private func getInspectableProperty(_ alignment: UIImageViewAlignmentMask) -> Bool {
         return self.alignment.contains(alignment)
+    }
+    
+    private func addRotationObserver() {
+        UIDevice.current.beginGeneratingDeviceOrientationNotifications()
+        NotificationCenter.default.addObserver(self, selector: #selector(updateLayout), name: UIDevice.orientationDidChangeNotification, object: nil)
     }
 }


### PR DESCRIPTION
When a rotation occurs call updateLayout 

Solves the [issue](https://github.com/sochalewski/UIImageViewAlignedSwift/issues/16) open