### PR TITLE
Fix original image reset on tvOS

### DIFF
--- a/UIImageViewAligned.swift
+++ b/UIImageViewAligned.swift
@@ -201,7 +201,7 @@ open class UIImageViewAligned: UIImageView {
     open override func didMoveToWindow() {
         super.didMoveToWindow()
         layer.contents = nil
-        if #available(iOS 11, *) {
+        if #available(tvOS 11, iOS 11, *) {
             let currentImage = realImageView?.image
             image = UIImage()
             realImageView?.image = currentImage
@@ -238,7 +238,7 @@ open class UIImageViewAligned: UIImageView {
         
         // Make sure we clear the contents of this container layer, since it refreshes from the image property once in a while.
         layer.contents = nil
-        if #available(iOS 11, *) {
+        if #available(tvOS 11, iOS 11, *) {
             super.image = UIImage()
         }
     }


### PR DESCRIPTION
The imageView was reset only for iOS 11, I've found the bug also on tvOS. Just updated `#available` condtions.