### PR TITLE
fix xcode  13 warning 

### DIFF
--- a/UIImageViewAligned.swift
+++ b/UIImageViewAligned.swift
@@ -12,7 +12,7 @@ public struct UIImageViewAlignmentMask: OptionSet {
     public init(rawValue: Int) { self.rawValue = rawValue }
     
     /// The option to align the content to the center.
-    public static let center = UIImageViewAlignmentMask(rawValue: 0)
+    public static let center = UIImageViewAlignmentMask([])
     /// The option to align the content to the left.
     public static let left = UIImageViewAlignmentMask(rawValue: 1 << 0)
     /// The option to align the content to the right.


### PR DESCRIPTION
fix xcode warning "Static property 'center' produces an empty option set"